### PR TITLE
feat: GPT Service 구현 및 StyleProfile 커스터마이징 기능 추가

### DIFF
--- a/docs/CURRENT_STATUS.md
+++ b/docs/CURRENT_STATUS.md
@@ -1,6 +1,6 @@
 # 프로젝트 현재 상태
 
-> 최종 업데이트: 2025-11-11 15:30
+> 최종 업데이트: 2025-11-18 15:10
 
 ## ✅ 완료된 작업
 
@@ -147,9 +147,67 @@ src/modules/kakao/
 
 ---
 
-## 🔄 최근 업데이트 (2025-11-12)
+## 🔄 최근 업데이트 (2025-11-18)
 
-### Phase 1 & 2: OpenAI 모듈 및 임베딩 생성 완료 ✅ **NEW!**
+### Phase 3: GPT Service 구현 완료 ✅ **NEW!**
+**구현 완료:**
+- ✅ GPT 모듈 생성 (`src/modules/gpt/`)
+- ✅ GptService 6개 핵심 메서드 구현
+  - `generateReply()` - 메인 답변 생성 메서드
+  - `getRecentContext()` - 최근 대화 20개 조회 (Conversation → Message)
+  - `getSimilarContext()` - pgvector 유사도 검색 (15개 예시)
+  - `getStyleProfile()` - ToneSample 통계 분석 (politeness, vibe)
+  - `getReceiverInfo()` - Partner & Relationship 정보 조회
+  - `buildPrompt()` - GPT 프롬프트 구성 (system + user messages)
+- ✅ GPT Controller 구현
+  - `POST /gpt/generate` - JWT 인증 보호, Swagger 문서화
+- ✅ DTO 및 Interface 정의
+  - `GenerateReplyDto` - 요청 검증 (userId, partnerId, message)
+  - `GenerateReplyResponse` - 응답 형식 (reply + context)
+- ✅ Swagger Authorization 이슈 해결
+  - `@ApiBearerAuth('access-token')` 추가로 토큰 전송 문제 해결
+
+**GPT 설정 최적화:**
+- Model: `gpt-4o-mini` (빠르고 저렴)
+- Temperature: 0.9 (창의적이고 자연스러운 답변)
+- Max Tokens: 100 (충분한 답변 길이)
+- Similar Examples: 15개 (풍부한 말투 컨텍스트)
+
+**E2E 테스트 완료:**
+- ✅ 로그인 → GPT 답변 생성 → 응답 확인
+- ✅ 벡터 유사도 검색 정상 작동 (HNSW 인덱스)
+- ✅ 관계별 정보 반영 확인 (FRIEND_CLOSE 등)
+- ✅ Context 디버깅 정보 포함 (recentMessages, similarExamples, styleProfile, receiverInfo)
+
+**테스트 결과 예시:**
+```json
+{
+  "reply": "뭐야, 뭐냐고? ㅋㅋ 지금 뭐 하는 중인데?",
+  "context": {
+    "recentMessages": [],
+    "similarExamples": ["?", "4시?", "그치..?", "제", "그래야 되는 거 아냐...??"],
+    "styleProfile": "",
+    "receiverInfo": "이유신 외 2명 (FRIEND_CLOSE)"
+  }
+}
+```
+
+**파일 구조:**
+```
+src/modules/gpt/
+├── gpt.module.ts
+├── gpt.controller.ts
+├── gpt.service.ts (370+ lines)
+├── dto/
+│   ├── generate-reply.dto.ts
+│   └── index.ts
+└── interfaces/
+    └── gpt.interface.ts
+```
+
+---
+
+### Phase 1 & 2: OpenAI 모듈 및 임베딩 생성 완료 ✅
 **구현 완료:**
 - ✅ OpenAI SDK 설치 및 모듈 생성 (`src/modules/openai/`)
 - ✅ OpenaiService 구현

--- a/docs/FRONTEND_API_GUIDE.md
+++ b/docs/FRONTEND_API_GUIDE.md
@@ -1,0 +1,687 @@
+# 프론트엔드 API 연동 가이드
+
+> 최종 업데이트: 2025-11-18
+>
+> **중요**: 이 문서는 프론트엔드 개발자를 위한 API 명세입니다.
+
+## 📋 목차
+
+1. [기본 정보](#기본-정보)
+2. [인증 (Authentication)](#인증-authentication)
+3. [GPT 답변 생성](#gpt-답변-생성)
+4. [말투 설정 관리 (StyleProfile)](#말투-설정-관리-styleprofile)
+5. [카카오톡 업로드](#카카오톡-업로드)
+6. [에러 처리](#에러-처리)
+
+---
+
+## 기본 정보
+
+### Base URL
+```
+http://localhost:3000
+```
+
+### Swagger 문서
+```
+http://localhost:3000/api
+```
+
+### 공통 헤더
+```http
+Content-Type: application/json
+Authorization: Bearer {access_token}
+```
+
+### 응답 형식
+모든 API는 JSON 형식으로 응답합니다.
+
+---
+
+## 인증 (Authentication)
+
+### 1. 회원가입
+
+**Endpoint**: `POST /auth/register`
+
+**Request Body**:
+```json
+{
+  "username": "mingyu",
+  "email": "mingyu@test.com",
+  "password": "password123",
+  "name": "이민규"
+}
+```
+
+**Response** (201 Created):
+```json
+{
+  "user": {
+    "id": "5ffc7298-98c5-44d0-a62e-7a2ac180a64d",
+    "username": "mingyu",
+    "name": "이민규",
+    "email": "mingyu@test.com",
+    "created_at": "2025-11-11T14:26:20.811Z"
+  },
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**필드 설명**:
+- `name`: **필수!** 카카오톡 파싱에 사용됨 (대화 내 이름과 일치해야 함)
+- `access_token`: 15분 유효 (API 호출 시 사용)
+- `refresh_token`: 30일 유효 (토큰 갱신 시 사용)
+
+---
+
+### 2. 로그인
+
+**Endpoint**: `POST /auth/login`
+
+**Request Body**:
+```json
+{
+  "email": "mingyu@test.com",
+  "password": "password123"
+}
+```
+
+**Response** (200 OK):
+```json
+{
+  "user": {
+    "id": "5ffc7298-98c5-44d0-a62e-7a2ac180a64d",
+    "username": "mingyu",
+    "name": "이민규",
+    "email": "mingyu@test.com",
+    "created_at": "2025-11-11T14:26:20.811Z"
+  },
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+---
+
+### 3. 토큰 갱신
+
+**Endpoint**: `POST /auth/refresh`
+
+**Request Body**:
+```json
+{
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**Response** (200 OK):
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**사용 시점**:
+- Access Token 만료 (401 Unauthorized) 시 자동 갱신
+- 프론트엔드에서 인터셉터 구현 권장
+
+---
+
+### 4. 현재 사용자 정보 조회
+
+**Endpoint**: `GET /auth/me`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+```
+
+**Response** (200 OK):
+```json
+{
+  "id": "5ffc7298-98c5-44d0-a62e-7a2ac180a64d",
+  "username": "mingyu",
+  "name": "이민규",
+  "email": "mingyu@test.com",
+  "created_at": "2025-11-11T14:26:20.811Z"
+}
+```
+
+---
+
+### 5. 로그아웃
+
+**Endpoint**: `POST /auth/logout`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+```
+
+**Response** (200 OK):
+```json
+{
+  "message": "Logged out successfully"
+}
+```
+
+**주의사항**:
+- 로그아웃 시 DB에 저장된 Refresh Token이 무효화됨
+- 로그아웃 후 저장된 토큰들을 로컬 스토리지에서 삭제해야 함
+
+---
+
+## GPT 답변 생성
+
+### 1. 답변 생성
+
+**Endpoint**: `POST /gpt/generate`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+Content-Type: application/json
+```
+
+**Request Body**:
+```json
+{
+  "userId": "5ffc7298-98c5-44d0-a62e-7a2ac180a64d",
+  "partnerId": "716d0ed5-c04e-4315-aa8c-05c5ade05b7e",
+  "message": "오늘 뭐해?"
+}
+```
+
+**Response** (200 OK):
+```json
+{
+  "reply": "뭐야, 뭐냐고? ㅋㅋ 지금 뭐 하는 중인데?",
+  "context": {
+    "recentMessages": [],
+    "similarExamples": [
+      "?",
+      "4시?",
+      "그치..?",
+      "제",
+      "그래야 되는 거 아냐...??"
+    ],
+    "styleProfile": "존댓말/반말: CASUAL, 말투 분위기: PLAYFUL, 분석된 대화 샘플: 523개",
+    "receiverInfo": "이유신 외 2명 (FRIEND_CLOSE)"
+  }
+}
+```
+
+**필드 설명**:
+- `userId`: 현재 로그인한 사용자의 ID (JWT에서 추출 가능)
+- `partnerId`: 대화 상대의 Partner ID (카카오톡 업로드 시 생성됨)
+- `message`: 상대방이 보낸 메시지 내용
+- `reply`: GPT가 생성한 답변
+- `context`: 디버깅 정보 (프론트에서 선택적 표시 가능)
+
+**에러 응답**:
+- `401 Unauthorized`: JWT 토큰 없음 또는 만료
+- `404 Not Found`: 사용자 또는 파트너를 찾을 수 없음
+
+**활용 예시**:
+```typescript
+// React/Next.js 예시
+const generateReply = async (partnerId: string, message: string) => {
+  const response = await fetch('http://localhost:3000/gpt/generate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      userId: currentUser.id,
+      partnerId,
+      message,
+    }),
+  });
+
+  const data = await response.json();
+  return data.reply; // "뭐야, 뭐냐고? ㅋㅋ 지금 뭐 하는 중인데?"
+};
+```
+
+---
+
+## 말투 설정 관리 (StyleProfile)
+
+### 🎯 개요
+
+사용자가 직접 자신의 말투 지향성을 설정할 수 있는 기능입니다.
+- GPT가 답변 생성 시 우선적으로 참고
+- 비속어, 이모티콘 사용 빈도, 문장 길이 등 제어
+- 관계 카테고리별 기본값 설정 가능
+
+---
+
+### 1. 말투 설정 저장/업데이트
+
+**Endpoint**: `POST /gpt/style-profile`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+Content-Type: application/json
+```
+
+**Request Body**:
+```json
+{
+  "customGuidelines": "- 비속어와 욕설을 사용하지 않음\n- 느낌표(!)를 거의 사용하지 않음\n- ㄷㄷ, ~, ㅋㅋㅋㅋ(연속 4개 이상) 사용 자제\n- 친구들에게는 반말, 선배에게는 존댓말\n- 짧고 간결한 문장 선호"
+}
+```
+
+**Response** (200 OK):
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "user_id": "5ffc7298-98c5-44d0-a62e-7a2ac180a64d",
+  "custom_guidelines": "- 비속어와 욕설을 사용하지 않음\n- 느낌표(!)를 거의 사용하지 않음\n- ㄷㄷ, ~, ㅋㅋㅋㅋ(연속 4개 이상) 사용 자제\n- 친구들에게는 반말, 선배에게는 존댓말\n- 짧고 간결한 문장 선호",
+  "updated_at": "2025-11-18T06:30:00.000Z"
+}
+```
+
+**UI 제안 사항**:
+```typescript
+// 프론트엔드 입력 폼 예시
+const styleProfileForm = {
+  useProfanity: false, // 비속어 사용 여부
+  useExclamation: 'rarely', // 느낌표 사용 빈도: never, rarely, sometimes, often
+  useEmoticons: 'moderate', // 이모티콘 사용 빈도: minimal, moderate, frequent
+  sentenceLength: 'short', // 문장 길이: short, medium, long
+  formalityByRelation: {
+    FRIEND_CLOSE: 'casual', // 친한 친구: 반말
+    SENIOR: 'formal', // 선배: 존댓말
+    // ... 10개 카테고리
+  }
+};
+
+// 이를 텍스트로 변환하여 전송
+const customGuidelines = `
+- 비속어 ${styleProfileForm.useProfanity ? '사용' : '사용하지 않음'}
+- 느낌표(!) ${exclamationMap[styleProfileForm.useExclamation]}
+- 이모티콘 사용 빈도: ${emoticonMap[styleProfileForm.useEmoticons]}
+- 문장 길이: ${lengthMap[styleProfileForm.sentenceLength]}
+- 친한 친구에게는 ${styleProfileForm.formalityByRelation.FRIEND_CLOSE === 'casual' ? '반말' : '존댓말'}
+`.trim();
+```
+
+---
+
+### 2. 말투 설정 조회
+
+**Endpoint**: `GET /gpt/style-profile`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+```
+
+**Response** (200 OK):
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "user_id": "5ffc7298-98c5-44d0-a62e-7a2ac180a64d",
+  "custom_guidelines": "- 비속어와 욕설을 사용하지 않음\n- 느낌표(!)를 거의 사용하지 않음\n- ㄷㄷ, ~, ㅋㅋㅋㅋ(연속 4개 이상) 사용 자제",
+  "updated_at": "2025-11-18T06:30:00.000Z"
+}
+```
+
+**Response** (404 Not Found - 설정 없음):
+```json
+{
+  "statusCode": 404,
+  "message": "Style profile not found",
+  "error": "Not Found"
+}
+```
+
+---
+
+### 3. 말투 설정 삭제 (기본값으로 리셋)
+
+**Endpoint**: `DELETE /gpt/style-profile`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+```
+
+**Response** (200 OK):
+```json
+{
+  "message": "Style profile deleted successfully"
+}
+```
+
+---
+
+## 카카오톡 업로드
+
+### 1. 카카오톡 txt 파일 업로드
+
+**Endpoint**: `POST /kakao/upload`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+Content-Type: multipart/form-data
+```
+
+**Request**:
+- Form Data로 파일 전송
+- Field name: `file`
+
+**Response** (201 Created):
+```json
+{
+  "message": "카카오톡 대화 업로드 성공",
+  "data": {
+    "total_messages": 523,
+    "my_messages_count": 261,
+    "unique_senders": ["이민규", "이유신", "김철수"],
+    "created_partners": [
+      {
+        "id": "716d0ed5-c04e-4315-aa8c-05c5ade05b7e",
+        "name": "이유신 외 2명",
+        "relationship_category": "FRIEND_CLOSE"
+      }
+    ]
+  }
+}
+```
+
+**파일 형식**:
+- 카카오톡 내보내기 기능으로 생성된 txt 파일
+- 두 가지 형식 지원:
+  1. `2024. 1. 15. 오후 3:45, 홍길동 : 안녕하세요`
+  2. `[이민규] [오후 1:03] 저는 아직 시간표도 못 짰습니다`
+
+**주의사항**:
+- 회원가입 시 입력한 `name`과 카카오톡 대화 내 이름이 **정확히 일치**해야 함
+- 업로드된 메시지는 자동으로 tone_samples 테이블에 저장됨
+- Partner와 Relationship이 자동 생성됨
+
+---
+
+### 2. Partner 목록 조회
+
+**Endpoint**: `GET /kakao/partners`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+```
+
+**Response** (200 OK):
+```json
+[
+  {
+    "id": "716d0ed5-c04e-4315-aa8c-05c5ade05b7e",
+    "name": "이유신 외 2명",
+    "created_at": "2025-11-11T14:30:00.000Z",
+    "relationship": {
+      "category": "FRIEND_CLOSE",
+      "politeness": "CASUAL",
+      "vibe": "PLAYFUL"
+    }
+  },
+  {
+    "id": "a2b3c4d5-e6f7-8901-bcde-f12345678901",
+    "name": "김교수님",
+    "created_at": "2025-11-12T10:15:00.000Z",
+    "relationship": {
+      "category": "PROFESSOR",
+      "politeness": "FORMAL",
+      "vibe": "CALM"
+    }
+  }
+]
+```
+
+**활용 예시**:
+- GPT 답변 생성 시 `partnerId` 선택을 위한 목록 표시
+- 관계 카테고리에 따라 UI에 아이콘/색상 표시 가능
+
+---
+
+### 3. 임베딩 생성
+
+**Endpoint**: `POST /kakao/generate-embeddings`
+
+**Headers**:
+```http
+Authorization: Bearer {access_token}
+```
+
+**Response** (200 OK):
+```json
+{
+  "message": "임베딩 생성 완료",
+  "stats": {
+    "total": 523,
+    "success": 523,
+    "failed": 0,
+    "total_tokens": 9352,
+    "estimated_cost_usd": 0.000187
+  }
+}
+```
+
+**사용 시점**:
+- 카카오톡 업로드 후 자동 호출 권장
+- 또는 사용자가 명시적으로 "학습하기" 버튼 클릭 시
+
+**주의사항**:
+- 처리 시간이 몇 초 소요될 수 있음 (배치 처리)
+- 이미 임베딩이 생성된 메시지는 건너뜀
+
+---
+
+## 에러 처리
+
+### 공통 에러 응답 형식
+
+```json
+{
+  "statusCode": 400,
+  "message": "에러 메시지",
+  "error": "Bad Request"
+}
+```
+
+### 주요 HTTP 상태 코드
+
+| 코드 | 의미 | 처리 방법 |
+|------|------|-----------|
+| 200 | 성공 | 정상 처리 |
+| 201 | 생성됨 | 리소스 생성 성공 |
+| 400 | 잘못된 요청 | 입력값 검증 실패, 메시지 표시 |
+| 401 | 인증 실패 | 토큰 갱신 시도 → 실패 시 로그인 페이지로 |
+| 404 | 찾을 수 없음 | 리소스 없음 안내 |
+| 500 | 서버 오류 | "일시적인 오류가 발생했습니다" 표시 |
+
+### 프론트엔드 인터셉터 예시
+
+```typescript
+// Axios 예시
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:3000',
+});
+
+// 요청 인터셉터 (토큰 자동 삽입)
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// 응답 인터셉터 (401 시 토큰 갱신)
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const refreshToken = localStorage.getItem('refresh_token');
+        const { data } = await axios.post('http://localhost:3000/auth/refresh', {
+          refresh_token: refreshToken,
+        });
+
+        localStorage.setItem('access_token', data.access_token);
+        localStorage.setItem('refresh_token', data.refresh_token);
+
+        originalRequest.headers.Authorization = `Bearer ${data.access_token}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        // 갱신 실패 → 로그아웃 처리
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('refresh_token');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default api;
+```
+
+---
+
+## 데이터 모델
+
+### 관계 카테고리 (RelationshipCategory)
+
+| 값 | 의미 | 기본 격식 수준 |
+|---|------|---------------|
+| `FRIEND_CLOSE` | 친한 친구 | 반말, 편한 말투 |
+| `FRIEND_ACQUAINTANCE` | 지인 | 반말, 약간 격식 |
+| `SENIOR` | 선배 | 존댓말, 적당한 격식 |
+| `JUNIOR` | 후배 | 반말 또는 존댓말 |
+| `COLLEAGUE` | 동료 | 존댓말, 격식 |
+| `PROFESSOR` | 교수님 | 존댓말, 높은 격식 |
+| `FAMILY` | 가족 | 상황에 따라 |
+| `ROMANTIC` | 연인 | 반말, 친밀함 |
+| `BUSINESS` | 비즈니스 관계 | 존댓말, 높은 격식 |
+| `OTHER` | 기타 | 기본값 (적당한 격식의 존댓말) |
+
+**기본값 (Default)**:
+- 카테고리 설정 없을 시: `OTHER`
+- 말투: 적당한 격식의 존댓말
+- 이모티콘: 최소 사용
+- 비속어: 사용하지 않음
+
+---
+
+## 데이터 필터링 FAQ
+
+### Q1. 비속어가 포함된 카카오톡 대화를 업로드해도 되나요?
+
+**A**: 네, 괜찮습니다.
+- 카카오톡 업로드는 **원본 데이터 그대로** DB에 저장합니다.
+- GPT가 답변 생성 시 **프롬프트의 제약 조건**에 따라 비속어를 **자동 필터링**합니다.
+- 사용자가 "말투 설정"에서 "비속어 사용하지 않음"을 선택하면, GPT는 학습 데이터에 비속어가 있어도 **생성하지 않습니다**.
+- 원본 데이터가 많을수록 GPT가 말투를 더 정확히 학습합니다.
+
+**권장사항**:
+- 모든 대화 내용을 업로드하세요 (비속어, 이모티콘 포함)
+- "말투 설정"에서 원하는 답변 스타일을 지정하세요
+- GPT가 알아서 필터링하여 답변을 생성합니다
+
+---
+
+### Q2. 관계 카테고리별로 말투를 다르게 설정하려면?
+
+**A**: "말투 설정" API를 사용하여 관계별 지침을 작성하세요.
+
+```json
+{
+  "customGuidelines": "- 친한 친구(FRIEND_CLOSE)에게는 반말, 이모티콘 자유롭게 사용\n- 선배(SENIOR)에게는 존댓말, 이모티콘 최소화\n- 교수님(PROFESSOR)에게는 높은 격식의 존댓말, 이모티콘 사용하지 않음"
+}
+```
+
+GPT가 답변 생성 시 `receiverInfo.category`를 참고하여 적절한 말투를 선택합니다.
+
+---
+
+### Q3. 기본 말투 (Default)는 어떻게 되나요?
+
+**A**: 사용자가 "말투 설정"을 하지 않은 경우:
+- **기본값**: 적당한 격식의 존댓말
+- **이모티콘**: 최소 사용
+- **비속어**: 사용하지 않음
+- **문장 길이**: 짧고 간결
+
+이는 처음 사용하는 사용자나 모든 관계에 대한 대화 데이터가 없을 때 안전한 기본값입니다.
+
+---
+
+## 개발 팁
+
+### 1. 토큰 저장
+
+```typescript
+// 로그인 성공 시
+const { access_token, refresh_token, user } = response.data;
+localStorage.setItem('access_token', access_token);
+localStorage.setItem('refresh_token', refresh_token);
+localStorage.setItem('user', JSON.stringify(user));
+```
+
+### 2. 파일 업로드 (React)
+
+```typescript
+const uploadKakaoFile = async (file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await fetch('http://localhost:3000/kakao/upload', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+    },
+    body: formData, // Content-Type은 자동 설정됨
+  });
+
+  return response.json();
+};
+```
+
+### 3. GPT 답변 스트리밍 (향후 지원 예정)
+
+현재는 전체 답변이 완성된 후 반환됩니다.
+향후 SSE(Server-Sent Events)를 통한 스트리밍 지원 예정입니다.
+
+---
+
+## 변경 이력
+
+| 날짜 | 버전 | 변경 내용 |
+|------|------|-----------|
+| 2025-11-18 | 1.2.0 | StyleProfile API 추가, Default 말투 설정 추가 |
+| 2025-11-18 | 1.1.0 | GPT Service 구현 완료, POST /gpt/generate 추가 |
+| 2025-11-12 | 1.0.0 | 초기 문서 작성 (Auth, Kakao 업로드) |
+
+---
+
+## 문의 및 지원
+
+- **Swagger 문서**: http://localhost:3000/api
+- **이슈 제보**: GitHub Issues
+- **API 테스트**: Swagger UI 또는 Postman 사용 권장

--- a/prisma/migrations/20251118061000_add_custom_guidelines/migration.sql
+++ b/prisma/migrations/20251118061000_add_custom_guidelines/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: Add custom_guidelines column to style_profiles
+ALTER TABLE "style_profiles" ADD COLUMN IF NOT EXISTS "custom_guidelines" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,12 +87,13 @@ model Relationship {
 }
 
 model StyleProfile {
-  id              String    @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  user_id         String    @unique @db.Uuid
-  honorific_rules Json?     @default("{}")
-  constraints     Json?     @default("{}")
-  updated_at      DateTime? @default(now()) @updatedAt @db.Timestamp(6)
-  user            User      @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id                String    @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  user_id           String    @unique @db.Uuid
+  honorific_rules   Json?     @default("{}")
+  constraints       Json?     @default("{}")
+  custom_guidelines String?   @db.Text
+  updated_at        DateTime? @default(now()) @updatedAt @db.Timestamp(6)
+  user              User      @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@map("style_profiles")
 }

--- a/scripts/check-embeddings.ts
+++ b/scripts/check-embeddings.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function checkEmbeddings() {
+  const result = await prisma.$queryRaw<
+    Array<{ user_id: string; count: bigint }>
+  >`
+    SELECT user_id, COUNT(*) as count
+    FROM tone_samples
+    WHERE embedding IS NOT NULL
+    GROUP BY user_id
+  `;
+
+  console.log('\n=== 임베딩 생성된 유저 ===\n');
+
+  for (const row of result) {
+    const user = await prisma.user.findUnique({
+      where: { id: row.user_id },
+      select: { name: true, email: true },
+    });
+
+    console.log(`User: ${user?.name} (${user?.email})`);
+    console.log(`  - user_id: ${row.user_id}`);
+    console.log(`  - 임베딩 개수: ${Number(row.count)}개\n`);
+  }
+
+  await prisma.$disconnect();
+}
+
+checkEmbeddings();

--- a/scripts/get-mingyu-data.ts
+++ b/scripts/get-mingyu-data.ts
@@ -1,0 +1,39 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  const userId = '5ffc7298-98c5-44d0-a62e-7a2ac180a64d';
+
+  const partners = await prisma.partner.findMany({
+    where: {
+      relationships: {
+        some: { user_id: userId },
+      },
+    },
+    take: 1,
+  });
+
+  console.log('\n=== Swagger 테스트용 Request Body ===\n');
+  console.log(
+    JSON.stringify(
+      {
+        userId: userId,
+        partnerId: partners[0]?.id || '',
+        message: '오늘 뭐해?',
+      },
+      null,
+      2,
+    ),
+  );
+
+  await prisma.$disconnect();
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/scripts/get-test-data.ts
+++ b/scripts/get-test-data.ts
@@ -1,0 +1,72 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function getTestData() {
+  console.log('\n=== 테스트 데이터 조회 ===\n');
+
+  // 1. 사용자 조회
+  const users = await prisma.user.findMany({
+    take: 3,
+    select: { id: true, name: true, email: true },
+  });
+  console.log('📌 Users:');
+  users.forEach((user) => {
+    console.log(`   ID: ${user.id}`);
+    console.log(`   Name: ${user.name}`);
+    console.log(`   Email: ${user.email}\n`);
+  });
+
+  // 2. 첫 번째 유저의 파트너 조회
+  if (users.length > 0) {
+    const userId = users[0].id;
+    const partners = await prisma.partner.findMany({
+      where: {
+        relationships: {
+          some: {
+            user_id: userId,
+          },
+        },
+      },
+      take: 3,
+      select: { id: true, name: true },
+    });
+
+    console.log(`📌 Partners for user ${users[0].name}:`);
+    partners.forEach((partner) => {
+      console.log(`   ID: ${partner.id}`);
+      console.log(`   Name: ${partner.name}\n`);
+    });
+
+    // 3. 임베딩 생성된 tone_samples 개수 확인
+    const toneSampleCount = await prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*) as count
+      FROM tone_samples
+      WHERE user_id = ${userId}::uuid AND embedding IS NOT NULL
+    `;
+    console.log(`📌 ToneSamples with embeddings: ${Number(toneSampleCount[0].count)}개\n`);
+
+    // 4. 테스트용 Request Body 출력
+    if (partners.length > 0) {
+      console.log('=== 테스트용 Request Body ===\n');
+      console.log(
+        JSON.stringify(
+          {
+            userId: userId,
+            partnerId: partners[0].id,
+            message: '오늘 뭐해?',
+          },
+          null,
+          2,
+        ),
+      );
+    }
+  }
+
+  await prisma.$disconnect();
+}
+
+getTestData().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});

--- a/scripts/verify-auth-data.ts
+++ b/scripts/verify-auth-data.ts
@@ -1,0 +1,85 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // test@mju.ac.kr 유저 정보
+  const user = await prisma.user.findUnique({
+    where: { email: 'test@mju.ac.kr' },
+  });
+
+  console.log('\n=== 로그인 계정 정보 ===');
+  console.log('Email:', user?.email);
+  console.log('User ID:', user?.id);
+  console.log('Name:', user?.name);
+
+  if (!user) {
+    console.log('\n❌ test@mju.ac.kr 계정을 찾을 수 없습니다!');
+    await prisma.$disconnect();
+    return;
+  }
+
+  // 이 유저의 파트너들
+  const partners = await prisma.partner.findMany({
+    where: {
+      relationships: {
+        some: { user_id: user.id },
+      },
+    },
+    include: {
+      relationships: {
+        where: { user_id: user.id },
+        select: {
+          category: true,
+          politeness: true,
+          vibe: true,
+        },
+      },
+    },
+  });
+
+  console.log('\n=== 파트너 목록 ===');
+  partners.forEach((p, idx) => {
+    console.log(`\n${idx + 1}. ${p.name}`);
+    console.log(`   Partner ID: ${p.id}`);
+    console.log(`   Category: ${p.relationships[0]?.category}`);
+    console.log(`   Politeness: ${p.relationships[0]?.politeness}`);
+    console.log(`   Vibe: ${p.relationships[0]?.vibe}`);
+  });
+
+  // 임베딩 개수 확인
+  const embCount = await prisma.$queryRaw<Array<{ count: bigint }>>`
+    SELECT COUNT(*) as count
+    FROM tone_samples
+    WHERE user_id = ${user.id}::uuid AND embedding IS NOT NULL
+  `;
+
+  console.log(`\n=== 임베딩 정보 ===`);
+  console.log(`임베딩 생성된 ToneSamples: ${Number(embCount[0].count)}개`);
+
+  if (partners.length > 0) {
+    console.log(`\n=== Swagger 테스트용 Request Body ===\n`);
+    console.log(
+      JSON.stringify(
+        {
+          userId: user.id,
+          partnerId: partners[0].id,
+          message: '오늘 뭐해?',
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  await prisma.$disconnect();
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { KakaoModule } from './modules/kakao/kakao.module';
 import { OpenaiModule } from './modules/openai/openai.module';
+import { GptModule } from './modules/gpt/gpt.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { OpenaiModule } from './modules/openai/openai.module';
     AuthModule,
     KakaoModule,
     OpenaiModule,
+    GptModule,
     TelegramModule,
   ],
   controllers: [AppController],

--- a/src/modules/auth/dto/login.dto.ts
+++ b/src/modules/auth/dto/login.dto.ts
@@ -4,7 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class LoginDto {
   @ApiProperty({
     description: '이메일 주소',
-    example: 'mingyu@test.com',
+    example: 'test@mju.ac.kr',
   })
   @IsEmail()
   @IsNotEmpty()
@@ -12,7 +12,7 @@ export class LoginDto {
 
   @ApiProperty({
     description: '비밀번호',
-    example: 'password123',
+    example: 'test123',
   })
   @IsString()
   @IsNotEmpty()

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
@@ -7,6 +7,8 @@ import { JwtUser, JwtPayload } from '../interfaces';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
+  private readonly logger = new Logger(JwtStrategy.name);
+
   constructor(
     private readonly configService: ConfigService,
     private readonly prisma: PrismaService,
@@ -16,11 +18,17 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       ignoreExpiration: false,
       secretOrKey: configService.get<string>('JWT_SECRET') || 'default-secret',
     });
+
+    this.logger.log('[JWT] JwtStrategy initialized');
   }
 
   async validate(payload: JwtPayload): Promise<JwtUser> {
+    this.logger.log(`[JWT] 🔑 Token validation started`);
+    this.logger.log(`[JWT] Payload: ${JSON.stringify(payload)}`);
+
     // JWT payload에서 user_id 추출
     const userId = payload.sub;
+    this.logger.log(`[JWT] Extracted userId: ${userId}`);
 
     // DB에서 사용자 확인
     const user = await this.prisma.user.findUnique({
@@ -35,8 +43,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
 
     if (!user) {
+      this.logger.error(`[JWT] ❌ User not found in DB: ${userId}`);
       throw new UnauthorizedException('User not found');
     }
+
+    this.logger.log(`[JWT] ✅ User validated: ${user.email} (${user.id})`);
 
     // Request 객체에 user 정보 추가
     // @UseGuards(JwtAuthGuard) 사용 시 req.user로 접근 가능

--- a/src/modules/gpt/dto/generate-reply.dto.ts
+++ b/src/modules/gpt/dto/generate-reply.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class GenerateReplyDto {
+  @ApiProperty({
+    description: '사용자 ID (UUID)',
+    example: '5ffc7298-98c5-44d0-a62e-7a2ac180a64d',
+  })
+  @IsNotEmpty()
+  @IsUUID()
+  userId: string;
+
+  @ApiProperty({
+    description: '대화 상대 Partner ID (UUID)',
+    example: '716d0ed5-c04e-4315-aa8c-05c5ade05b7e',
+  })
+  @IsNotEmpty()
+  @IsUUID()
+  partnerId: string;
+
+  @ApiProperty({
+    description: '수신한 메시지 내용',
+    example: '오늘 뭐해?',
+  })
+  @IsNotEmpty()
+  @IsString()
+  message: string;
+}

--- a/src/modules/gpt/dto/index.ts
+++ b/src/modules/gpt/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './generate-reply.dto';
+export * from './update-style-profile.dto';

--- a/src/modules/gpt/dto/update-style-profile.dto.ts
+++ b/src/modules/gpt/dto/update-style-profile.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateStyleProfileDto {
+  @ApiProperty({
+    description: '사용자 정의 말투 지침',
+    example:
+      '- 비속어와 욕설을 사용하지 않음\n- 느낌표(!)를 거의 사용하지 않음\n- ㄷㄷ, ~, ㅋㅋㅋㅋ(연속 4개 이상) 사용 자제\n- 친구들에게는 반말, 선배에게는 존댓말\n- 짧고 간결한 문장 선호',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  customGuidelines?: string;
+}

--- a/src/modules/gpt/gpt.controller.ts
+++ b/src/modules/gpt/gpt.controller.ts
@@ -1,0 +1,134 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GenerateReplyDto, UpdateStyleProfileDto } from './dto';
+import { GptService } from './gpt.service';
+import { GenerateReplyResponse } from './interfaces/gpt.interface';
+import { Request } from 'express';
+
+@ApiTags('GPT')
+@ApiBearerAuth('access-token')
+@Controller('gpt')
+@UseGuards(JwtAuthGuard)
+export class GptController {
+  constructor(private readonly gptService: GptService) {}
+
+  @Post('generate')
+  @ApiOperation({
+    summary: 'GPT 답변 생성',
+    description:
+      '사용자의 말투를 모방하여 GPT 기반 답변을 생성합니다. 벡터 유사도 검색으로 말투 예시를 찾고, 최근 대화 맥락과 관계 정보를 활용합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '답변 생성 성공',
+    schema: {
+      example: {
+        reply: '오 ㅋㅋ 나도 별로 안 바쁨',
+        context: {
+          recentMessages: [],
+          similarExamples: ['ㅇㅇ 그럼', '알겠어 ㅋㅋ', '오케이~'],
+          styleProfile:
+            '존댓말/반말: CASUAL, 말투 분위기: PLAYFUL, 분석된 대화 샘플: 523개',
+          receiverInfo: '친구 (FRIEND_CLOSE)',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: '인증 실패 (JWT 토큰 없음)' })
+  @ApiResponse({
+    status: 404,
+    description: '사용자 또는 파트너를 찾을 수 없음',
+  })
+  async generateReply(
+    @Body() dto: GenerateReplyDto,
+  ): Promise<GenerateReplyResponse> {
+    return this.gptService.generateReply(
+      dto.userId,
+      dto.partnerId,
+      dto.message,
+    );
+  }
+
+  @Post('style-profile')
+  @ApiOperation({
+    summary: '말투 설정 저장/업데이트',
+    description:
+      '사용자 정의 말투 지침을 저장합니다. GPT 답변 생성 시 우선적으로 참고됩니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '말투 설정 저장 성공',
+    schema: {
+      example: {
+        id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        user_id: '5ffc7298-98c5-44d0-a62e-7a2ac180a64d',
+        custom_guidelines:
+          '- 비속어와 욕설을 사용하지 않음\n- 느낌표(!)를 거의 사용하지 않음',
+        updated_at: '2025-11-18T06:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: '인증 실패' })
+  async updateStyleProfile(
+    @Req() req: Request & { user: { id: string } },
+    @Body() dto: UpdateStyleProfileDto,
+  ) {
+    return this.gptService.updateStyleProfile(req.user.id, dto);
+  }
+
+  @Get('style-profile')
+  @ApiOperation({
+    summary: '말투 설정 조회',
+    description: '현재 사용자의 말투 설정을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '말투 설정 조회 성공',
+    schema: {
+      example: {
+        id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        user_id: '5ffc7298-98c5-44d0-a62e-7a2ac180a64d',
+        custom_guidelines:
+          '- 비속어와 욕설을 사용하지 않음\n- 느낌표(!)를 거의 사용하지 않음',
+        updated_at: '2025-11-18T06:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: '말투 설정을 찾을 수 없음' })
+  async getStyleProfile(@Req() req: Request & { user: { id: string } }) {
+    return this.gptService.getStyleProfileSettings(req.user.id);
+  }
+
+  @Delete('style-profile')
+  @ApiOperation({
+    summary: '말투 설정 삭제',
+    description: '사용자 정의 말투 설정을 삭제하고 기본값으로 돌아갑니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '말투 설정 삭제 성공',
+    schema: {
+      example: {
+        message: 'Style profile deleted successfully',
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: '말투 설정을 찾을 수 없음' })
+  async deleteStyleProfile(@Req() req: Request & { user: { id: string } }) {
+    return this.gptService.deleteStyleProfile(req.user.id);
+  }
+}

--- a/src/modules/gpt/gpt.module.ts
+++ b/src/modules/gpt/gpt.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { OpenaiModule } from '../openai/openai.module';
+import { GptController } from './gpt.controller';
+import { GptService } from './gpt.service';
+
+@Module({
+  imports: [PrismaModule, OpenaiModule],
+  controllers: [GptController],
+  providers: [GptService],
+  exports: [GptService],
+})
+export class GptModule {}

--- a/src/modules/gpt/gpt.service.ts
+++ b/src/modules/gpt/gpt.service.ts
@@ -1,0 +1,507 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { OpenaiService } from '../openai/openai.service';
+import {
+  GenerateReplyResponse,
+  RecentContext,
+  ReceiverInfo,
+  SimilarContext,
+  StyleProfile,
+} from './interfaces/gpt.interface';
+import { ChatMessage } from '../openai/interfaces/openai.interface';
+import { UpdateStyleProfileDto } from './dto';
+
+@Injectable()
+export class GptService {
+  private readonly logger = new Logger(GptService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly openai: OpenaiService,
+  ) {}
+
+  /**
+   * 최근 대화 내역 조회
+   * @param userId 사용자 ID
+   * @param partnerId 대화 상대 Partner ID
+   * @param limit 조회할 메시지 수 (기본 20개)
+   */
+  async getRecentContext(
+    userId: string,
+    partnerId: string,
+    limit = 20,
+  ): Promise<RecentContext> {
+    this.logger.log(
+      `Fetching recent ${limit} messages for user ${userId} with partner ${partnerId}`,
+    );
+
+    // Conversation을 먼저 찾고, 해당 Conversation의 메시지들을 조회
+    const conversation = await this.prisma.conversation.findFirst({
+      where: {
+        user_id: userId,
+        partner_id: partnerId,
+      },
+    });
+
+    if (!conversation) {
+      this.logger.warn(
+        `No conversation found for user ${userId} and partner ${partnerId}`,
+      );
+      return { messages: [] };
+    }
+
+    const messages = await this.prisma.message.findMany({
+      where: {
+        conversation_id: conversation.id,
+      },
+      orderBy: {
+        created_at: 'desc',
+      },
+      take: limit,
+      select: {
+        role: true,
+        text: true,
+        created_at: true,
+      },
+    });
+
+    // 시간 순서대로 정렬 (오래된 것부터)
+    const orderedMessages = messages.reverse().map((msg) => ({
+      sender: msg.role === 'user' ? 'user' : 'assistant',
+      content: msg.text,
+      timestamp: msg.created_at || new Date(),
+    }));
+
+    return {
+      messages: orderedMessages,
+    };
+  }
+
+  /**
+   * 벡터 유사도 검색 (pgvector)
+   * @param userId 사용자 ID
+   * @param messageContent 검색할 메시지 내용
+   * @param limit 조회할 개수 (기본 5개)
+   */
+  async getSimilarContext(
+    userId: string,
+    messageContent: string,
+    limit = 5,
+  ): Promise<SimilarContext> {
+    this.logger.log(
+      `Searching similar tone samples for user ${userId}, limit ${limit}`,
+    );
+
+    // 1. 메시지 임베딩 생성
+    const { embedding } = await this.openai.createEmbedding(messageContent);
+    const vectorString = `[${embedding.join(',')}]`;
+
+    // 2. pgvector 코사인 유사도 검색 (HNSW 인덱스 활용)
+    const similarSamples = await this.prisma.$queryRaw<
+      Array<{ text: string; similarity: number }>
+    >`
+      SELECT
+        text,
+        1 - (embedding <=> ${vectorString}::vector) as similarity
+      FROM tone_samples
+      WHERE user_id = ${userId}::uuid
+        AND embedding IS NOT NULL
+      ORDER BY embedding <=> ${vectorString}::vector
+      LIMIT ${limit}
+    `;
+
+    this.logger.log(`Found ${similarSamples.length} similar examples`);
+
+    return {
+      examples: similarSamples,
+    };
+  }
+
+  /**
+   * 사용자 말투 프로필 조회
+   * @param userId 사용자 ID
+   */
+  async getStyleProfile(userId: string): Promise<StyleProfile> {
+    this.logger.log(`Fetching style profile for user ${userId}`);
+
+    const profile = await this.prisma.styleProfile.findUnique({
+      where: { user_id: userId },
+    });
+
+    if (!profile) {
+      this.logger.warn(`No style profile found for user ${userId}`);
+      return {
+        characteristics: [],
+      };
+    }
+
+    const characteristics: string[] = [];
+
+    // StyleProfile은 honorific_rules, constraints만 있음
+    // ToneSample에서 통계 계산 또는 제약 조건 사용
+    const toneSamples = await this.prisma.toneSample.findMany({
+      where: { user_id: userId },
+      select: {
+        politeness: true,
+        vibe: true,
+        category: true,
+      },
+      take: 100, // 최근 100개 샘플 분석
+    });
+
+    // 말투 특징 추출 (가장 빈도 높은 값)
+    const politenessCount = new Map<string, number>();
+    const vibeCount = new Map<string, number>();
+
+    toneSamples.forEach((sample) => {
+      if (sample.politeness) {
+        politenessCount.set(
+          sample.politeness,
+          (politenessCount.get(sample.politeness) || 0) + 1,
+        );
+      }
+      if (sample.vibe) {
+        vibeCount.set(sample.vibe, (vibeCount.get(sample.vibe) || 0) + 1);
+      }
+    });
+
+    // 가장 빈도 높은 말투 특징
+    let maxPoliteness = '';
+    let maxPolitenessCount = 0;
+    politenessCount.forEach((count, level) => {
+      if (count > maxPolitenessCount) {
+        maxPoliteness = level;
+        maxPolitenessCount = count;
+      }
+    });
+
+    let maxVibe = '';
+    let maxVibeCount = 0;
+    vibeCount.forEach((count, vibe) => {
+      if (count > maxVibeCount) {
+        maxVibe = vibe;
+        maxVibeCount = count;
+      }
+    });
+
+    if (maxPoliteness) {
+      characteristics.push(`존댓말/반말: ${maxPoliteness}`);
+    }
+    if (maxVibe) {
+      characteristics.push(`말투 분위기: ${maxVibe}`);
+    }
+
+    characteristics.push(`분석된 대화 샘플: ${toneSamples.length}개`);
+
+    return {
+      politenessLevel: maxPoliteness || undefined,
+      vibeType: maxVibe || undefined,
+      characteristics,
+    };
+  }
+
+  /**
+   * 수신자 (대화 상대) 정보 조회
+   * @param userId 사용자 ID
+   * @param partnerId Partner ID
+   */
+  async getReceiverInfo(
+    userId: string,
+    partnerId: string,
+  ): Promise<ReceiverInfo> {
+    this.logger.log(`Fetching receiver info for partner ${partnerId}`);
+
+    // Partner 정보 조회
+    const partner = await this.prisma.partner.findUnique({
+      where: { id: partnerId },
+    });
+
+    if (!partner) {
+      throw new NotFoundException(`Partner not found: ${partnerId}`);
+    }
+
+    // Relationship 정보 조회
+    const relationship = await this.prisma.relationship.findFirst({
+      where: {
+        user_id: userId,
+        partner_id: partnerId,
+      },
+    });
+
+    return {
+      name: partner.name,
+      // 관계 정보가 없으면 격식 있는 존댓말 카테고리 (ACQUAINTANCE_CASUAL) 사용
+      category: relationship?.category || 'ACQUAINTANCE_CASUAL',
+      relationshipDescription: relationship
+        ? `${relationship.politeness || 'CASUAL'}, ${relationship.vibe || 'CALM'}`
+        : '격식 있는 존댓말', // 관계 정보 없을 때 기본 설명
+    };
+  }
+
+  /**
+   * GPT 프롬프트 구성 (FastAPI 로직 포팅)
+   * @param userName 사용자 이름
+   * @param styleProfile 말투 프로필
+   * @param recentContext 최근 대화
+   * @param similarContext 유사 말투 예시
+   * @param receiverInfo 수신자 정보
+   * @param message 수신한 메시지
+   * @param customGuidelines 사용자 정의 말투 지침 (선택)
+   */
+  buildPrompt(
+    userName: string,
+    styleProfile: StyleProfile,
+    recentContext: RecentContext,
+    similarContext: SimilarContext,
+    receiverInfo: ReceiverInfo,
+    message: string,
+    customGuidelines?: string,
+  ): ChatMessage[] {
+    // 말투 예시 텍스트 (유사도 높은 순)
+    const profileText = similarContext.examples.map((ex) => ex.text).join('\n');
+
+    // 최근 대화 텍스트
+    const recentMessagesText = recentContext.messages
+      .map((msg) => `${msg.sender}: ${msg.content}`)
+      .join('\n');
+
+    // 기본 제약 조건 (사용자 정의 지침이 없을 경우)
+    // 개인차가 큰 항목은 제외하고, 최소한의 일반적인 가이드만 제공
+    const defaultConstraints = `
+[답변 제약 조건]
+- 제공된 말투 예시를 참고하여 자연스럽게 답변
+- 대화 상대와의 관계(${receiverInfo.category})에 맞는 격식 수준 유지
+- 관계 정보가 없는 대상(ACQUAINTANCE_CASUAL)에게는 격식 있는 존댓말 사용
+- 최근 대화 맥락을 고려하여 일관성 있는 톤 유지
+`;
+
+    // 사용자 정의 지침 또는 기본 제약 조건
+    const constraints = customGuidelines
+      ? `\n[사용자 정의 말투 지침]\n${customGuidelines}\n`
+      : defaultConstraints;
+
+    // System prompt
+    const systemContent = `너는 사용자 '${userName}'의 말투를 모방하는 AI야. 반드시 주어진 말투 특징과 대화 상대의 관계를 반영해야 해.
+
+아래 대화록은 ${userName}의 실제 말투 예시야.
+${userName}의 문장 리듬, 감탄사, 억양, 말끝, 문장 길이를 세밀하게 분석해 그대로 반영해.
+하지만 답변은 자연스럽고 짧게, 최대 두 문장에서 세 문장 이내로 핵심만 말해. 불필요한 반복이나 긴 설명은 하지 마.
+
+[말투 예시]
+${profileText}
+
+[대화 상대 정보]
+이름: ${receiverInfo.name}
+관계: ${receiverInfo.category}
+${receiverInfo.relationshipDescription ? `설명: ${receiverInfo.relationshipDescription}` : ''}
+
+[최근 대화 맥락]
+${recentMessagesText || '(최근 대화 없음)'}
+
+[말투 분석 결과]
+${styleProfile.characteristics.length > 0 ? styleProfile.characteristics.join('\n') : '(분석 중)'}
+${constraints}
+
+위 제약 조건을 엄격히 준수하면서, 위 말투 예시와 유사한 스타일로 자연스럽게 답변해줘.`;
+
+    const userContent = `${receiverInfo.name}: ${message}`;
+
+    return [
+      { role: 'system' as const, content: systemContent },
+      { role: 'user' as const, content: userContent },
+    ];
+  }
+
+  /**
+   * 사용자 정의 말투 지침 조회 (타입 안전)
+   * @param userId 사용자 ID
+   */
+  private async getCustomGuidelines(
+    userId: string,
+  ): Promise<string | undefined> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{ custom_guidelines: string | null }>
+    >`
+      SELECT custom_guidelines
+      FROM style_profiles
+      WHERE user_id = ${userId}::uuid
+      LIMIT 1
+    `;
+    return rows[0]?.custom_guidelines || undefined;
+  }
+
+  /**
+   * GPT 답변 생성 (메인 메서드)
+   * @param userId 사용자 ID
+   * @param partnerId 대화 상대 Partner ID
+   * @param message 수신한 메시지
+   */
+  async generateReply(
+    userId: string,
+    partnerId: string,
+    message: string,
+  ): Promise<GenerateReplyResponse> {
+    this.logger.log(
+      `[GPT] 📨 요청 수신 - userId: ${userId}, partnerId: ${partnerId}, message: "${message}"`,
+    );
+
+    // 1. 사용자 정보 조회
+    this.logger.log(`[GPT] 1️⃣ 사용자 정보 조회 중...`);
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      this.logger.error(`[GPT] ❌ 사용자를 찾을 수 없음: ${userId}`);
+      throw new NotFoundException(`User not found: ${userId}`);
+    }
+
+    const userName = user.name || 'User';
+    this.logger.log(`[GPT] ✅ 사용자 찾음: ${userName} (${user.email})`);
+
+    // 2. 컨텍스트 수집 (병렬 처리) + 사용자 정의 지침 조회
+    this.logger.log(`[GPT] 2️⃣ 컨텍스트 수집 시작 (5개 병렬 쿼리)...`);
+    const [
+      recentContext,
+      similarContext,
+      styleProfile,
+      receiverInfo,
+      userStyleProfile,
+    ] = await Promise.all([
+      this.getRecentContext(userId, partnerId, 20),
+      this.getSimilarContext(userId, message, 15), // 5 → 15로 증가
+      this.getStyleProfile(userId),
+      this.getReceiverInfo(userId, partnerId),
+      // 사용자 정의 말투 지침 조회 (Raw Query로 타입 오류 회피)
+      this.prisma.$queryRaw<Array<{ custom_guidelines: string | null }>>`
+        SELECT custom_guidelines
+        FROM style_profiles
+        WHERE user_id = ${userId}::uuid
+        LIMIT 1
+      `.then((rows) => rows[0] || null),
+    ]);
+
+    const customGuidelines = userStyleProfile?.custom_guidelines || undefined;
+
+    this.logger.log(
+      `[GPT] ✅ 컨텍스트 수집 완료 - 최근 메시지: ${recentContext.messages.length}개, 유사 예시: ${similarContext.examples.length}개, 사용자 지침: ${customGuidelines ? '있음' : '기본값'}`,
+    );
+
+    // 3. 프롬프트 구성
+    this.logger.log(`[GPT] 3️⃣ GPT 프롬프트 구성 중...`);
+    const messages = this.buildPrompt(
+      userName,
+      styleProfile,
+      recentContext,
+      similarContext,
+      receiverInfo,
+      message,
+      customGuidelines,
+    );
+    this.logger.log(
+      `[GPT] ✅ 프롬프트 구성 완료 (메시지 ${messages.length}개)`,
+    );
+
+    // 4. GPT API 호출 (말투 재현성 개선을 위해 파라미터 조정)
+    this.logger.log(
+      `[GPT] 4️⃣ OpenAI GPT API 호출 중... (temperature: 0.9, maxTokens: 100)`,
+    );
+    const completion = await this.openai.generateChatCompletion(messages, {
+      temperature: 0.9, // 0.7 → 0.9 (더 창의적이고 자연스러운 답변)
+      maxTokens: 100, // 60 → 100 (더 긴 답변 가능)
+    });
+
+    const reply = completion.content;
+
+    this.logger.log(`[GPT] ✅ GPT 답변 생성 성공: "${reply}"`);
+
+    // 5. 응답 반환 (디버깅용 컨텍스트 포함)
+    const response = {
+      reply,
+      context: {
+        recentMessages: recentContext.messages.map((m) => m.content),
+        similarExamples: similarContext.examples.map((e) => e.text),
+        styleProfile: styleProfile.characteristics.join(', '),
+        receiverInfo: `${receiverInfo.name} (${receiverInfo.category})`,
+      },
+    };
+
+    this.logger.log(`[GPT] 🎉 응답 반환 완료`);
+    return response;
+  }
+
+  /**
+   * 말투 설정 저장/업데이트
+   * @param userId 사용자 ID
+   * @param dto 업데이트할 말투 설정
+   */
+  async updateStyleProfile(userId: string, dto: UpdateStyleProfileDto) {
+    this.logger.log(
+      `[GPT] 말투 설정 업데이트 - userId: ${userId}, guidelines: ${dto.customGuidelines ? '있음' : '없음'}`,
+    );
+
+    // Upsert: 존재하면 업데이트, 없으면 생성
+    await this.prisma.$executeRaw`
+      INSERT INTO style_profiles (user_id, custom_guidelines, updated_at)
+      VALUES (${userId}::uuid, ${dto.customGuidelines || null}, NOW())
+      ON CONFLICT (user_id)
+      DO UPDATE SET
+        custom_guidelines = ${dto.customGuidelines || null},
+        updated_at = NOW()
+    `;
+
+    // 조회하여 반환
+    const updated = await this.prisma.styleProfile.findUnique({
+      where: { user_id: userId },
+    });
+
+    this.logger.log(`[GPT] ✅ 말투 설정 업데이트 완료`);
+    return updated;
+  }
+
+  /**
+   * 말투 설정 조회
+   * @param userId 사용자 ID
+   */
+  async getStyleProfileSettings(userId: string) {
+    this.logger.log(`[GPT] 말투 설정 조회 - userId: ${userId}`);
+
+    const styleProfile = await this.prisma.styleProfile.findUnique({
+      where: { user_id: userId },
+    });
+
+    if (!styleProfile) {
+      this.logger.warn(`[GPT] ⚠️ 말투 설정 없음 - userId: ${userId}`);
+      throw new NotFoundException('Style profile not found');
+    }
+
+    return styleProfile;
+  }
+
+  /**
+   * 말투 설정 삭제 (기본값으로 리셋)
+   * @param userId 사용자 ID
+   */
+  async deleteStyleProfile(userId: string) {
+    this.logger.log(`[GPT] 말투 설정 삭제 - userId: ${userId}`);
+
+    const styleProfile = await this.prisma.styleProfile.findUnique({
+      where: { user_id: userId },
+    });
+
+    if (!styleProfile) {
+      this.logger.warn(`[GPT] ⚠️ 삭제할 말투 설정 없음 - userId: ${userId}`);
+      throw new NotFoundException('Style profile not found');
+    }
+
+    // custom_guidelines만 NULL로 업데이트
+    await this.prisma.$executeRaw`
+      UPDATE style_profiles
+      SET custom_guidelines = NULL, updated_at = NOW()
+      WHERE user_id = ${userId}::uuid
+    `;
+
+    this.logger.log(`[GPT] ✅ 말투 설정 삭제 완료 (기본값으로 리셋)`);
+    return { message: 'Style profile deleted successfully' };
+  }
+}

--- a/src/modules/gpt/interfaces/gpt.interface.ts
+++ b/src/modules/gpt/interfaces/gpt.interface.ts
@@ -1,0 +1,60 @@
+/**
+ * GPT 답변 생성 요청 파라미터
+ */
+export interface GenerateReplyRequest {
+  userId: string; // 사용자 ID
+  partnerId: string; // 대화 상대 Partner ID
+  message: string; // 수신한 메시지 내용
+}
+
+/**
+ * GPT 답변 생성 응답
+ */
+export interface GenerateReplyResponse {
+  reply: string; // 생성된 답변
+  context?: {
+    recentMessages?: string[]; // 최근 대화 맥락
+    similarExamples?: string[]; // 유사한 말투 예시
+    styleProfile?: string; // 말투 프로필 정보
+    receiverInfo?: string; // 수신자 관계 정보
+  };
+}
+
+/**
+ * 최근 대화 컨텍스트
+ */
+export interface RecentContext {
+  messages: Array<{
+    sender: string;
+    content: string;
+    timestamp: Date;
+  }>;
+}
+
+/**
+ * 유사도 검색 결과
+ */
+export interface SimilarContext {
+  examples: Array<{
+    text: string;
+    similarity: number; // 코사인 유사도 (0-1)
+  }>;
+}
+
+/**
+ * 말투 프로필
+ */
+export interface StyleProfile {
+  politenessLevel?: string; // 존댓말/반말
+  vibeType?: string; // 말투 분위기
+  characteristics: string[]; // 특징 리스트
+}
+
+/**
+ * 수신자 정보
+ */
+export interface ReceiverInfo {
+  name: string;
+  category: string; // 관계 카테고리
+  relationshipDescription?: string;
+}

--- a/test-gpt-api.ps1
+++ b/test-gpt-api.ps1
@@ -1,0 +1,39 @@
+# GPT API 테스트 스크립트
+
+Write-Host "=== Step 1: Login ===" -ForegroundColor Green
+$loginResponse = Invoke-RestMethod -Uri "http://localhost:3000/auth/login" `
+    -Method Post `
+    -ContentType "application/json" `
+    -Body '{"email":"test@mju.ac.kr","password":"test123"}'
+
+$token = $loginResponse.accessToken
+Write-Host "Token received: $($token.Substring(0, 50))..." -ForegroundColor Yellow
+
+Write-Host "`n=== Step 2: Call GPT Generate ===" -ForegroundColor Green
+$headers = @{
+    "Authorization" = "Bearer $token"
+    "Content-Type" = "application/json"
+}
+
+$body = @{
+    userId = "5ffc7298-98c5-44d0-a62e-7a2ac180a64d"
+    partnerId = "716d0ed5-c04e-4315-aa8c-05c5ade05b7e"
+    message = "오늘 뭐해?"
+} | ConvertTo-Json
+
+Write-Host "Request Body:" -ForegroundColor Cyan
+Write-Host $body
+
+try {
+    $response = Invoke-RestMethod -Uri "http://localhost:3000/gpt/generate" `
+        -Method Post `
+        -Headers $headers `
+        -Body $body
+
+    Write-Host "`n=== Success! ===" -ForegroundColor Green
+    Write-Host ($response | ConvertTo-Json -Depth 10)
+} catch {
+    Write-Host "`n=== Error! ===" -ForegroundColor Red
+    Write-Host "Status Code: $($_.Exception.Response.StatusCode.value__)"
+    Write-Host "Error: $_"
+}


### PR DESCRIPTION
- GPT 모듈 생성 및 답변 생성 서비스 구현
  - POST /gpt/generate: 말투 모방 답변 생성 API
  - 최근 대화 20개 조회 (getRecentContext)
  - pgvector 유사도 검색 15개 예시 (getSimilarContext)
  - 관계 정보 기반 격식 수준 조정 (getReceiverInfo)
  - ToneSample 통계 분석 (getStyleProfile)

- StyleProfile 커스터마이징 API 구현
  - POST /gpt/style-profile: 사용자 정의 말투 지침 저장
  - GET /gpt/style-profile: 현재 설정 조회
  - DELETE /gpt/style-profile: 기본값으로 리셋
  - DB 스키마에 custom_guidelines 필드 추가

- 기본 제약 조건 및 존댓말 처리
  - 관계 정보 없을 시 ACQUAINTANCE_CASUAL (격식 있는 존댓말) 사용
  - 사용자 지침 없을 때 중립적인 기본 제약 조건 적용
  - 개인화 가능한 항목은 하드코딩 제거

- 프론트엔드 API 가이드 작성
  - docs/FRONTEND_API_GUIDE.md 추가
  - 모든 API 엔드포인트 명세 및 예시 코드
  - 에러 처리 및 인터셉터 구현 가이드
  - FAQ 섹션 추가 (비속어 필터링, 관계별 말투 등)

- 개발 스크립트 추가
  - scripts/verify-auth-data.ts: 테스트 계정 데이터 확인
  - scripts/get-mingyu-data.ts: Swagger 테스트용 데이터 조회
  - scripts/check-embeddings.ts: 임베딩 생성 현황 확인
  - scripts/get-test-data.ts: 전체 테스트 데이터 조회

- 기타 개선사항
  - JWT 전략에 상세 로깅 추가
  - Prisma 마이그레이션으로 스키마 변경 관리
  - Temperature 0.9, MaxTokens 100 최적화
  - CURRENT_STATUS.md 업데이트 (Phase 3 완료)